### PR TITLE
fix: Fix that themeConfig.navbar.links has been renamed to themeConfig.navbar.items

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -13,7 +13,7 @@ module.exports = {
         alt: 'Eik Logo',
         src: 'img/logo.svg',
       },
-      links: [
+      items: [
         {
           to: 'docs/overview',
           activeBasePath: 'docs',


### PR DESCRIPTION
Fixes that deployment breaks: https://github.com/eik-lib/eik-lib.github.io/runs/949100889?check_suite_focus=true