### PR TITLE
chore: Group docusaurus dependencies in renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
   ],
   "packageRules": [{
     "depTypeList": ["dependencies"],
+    "schedule": ["before 4am on monday"],
     "automerge": true,
     "major": {
       "automerge": false
@@ -13,11 +14,13 @@
   {
     "depTypeList": ["devDependencies"],
     "schedule": ["before 4am on monday"],
-    "commitMessage": "Dev dependency {{depName}} updated to version {{newValue}}",
-    "prTitle": "Dev dependency update: {{depName}}",
     "automerge": true,
     "major": {
       "automerge": false
     }
+  },
+  {
+    "groupName": "docusaurus release packages",
+    "packagePatterns": ["^@docusaurus/"]
   }]
 }


### PR DESCRIPTION
Docusaurus modules seems to always be published on the same time. Group them into one PR instead of multiple.