### PR TITLE
docs: Add section about mapping modules

### DIFF
--- a/docs/mapping_browser.md
+++ b/docs/mapping_browser.md
@@ -1,0 +1,20 @@
+---
+id: mapping_browser
+title: Browser Support
+sidebar_label: Browser Support
+---
+
+Eventually browsers will support Import Maps but currently (October 2020) no browser is shipped with Import Map enabeled. 
+
+Chromium based browsers does ship support for Import Maps as an [experimental feature](https://www.chromestatus.com/feature/5315286962012160) which has to be turned on by enabling the Experimental Productivity Features flag in Chromium based browsers:
+
+ - [Chrome](chrome://flags/#enable-experimental-productivity-features)
+ - [Brave](brave://flags/#enable-experimental-productivity-features)
+ - [Opera](opera://flags/#enable-experimental-productivity-features)
+ - [Edge](edge://flags/#enable-experimental-productivity-features)
+ 
+## Import Map Polyfill
+
+Import Maps can be polyfilled by the following modules:
+
+ - [es-module-shims](https://github.com/guybedford/es-module-shims)

--- a/docs/mapping_browser.md
+++ b/docs/mapping_browser.md
@@ -4,7 +4,7 @@ title: Browser Support
 sidebar_label: Browser Support
 ---
 
-Eventually browsers will support Import Maps but currently (October 2020) no browser is shipped with Import Map enabeled. 
+Eventually, browsers will support Import Maps but currently (October 2020) no browser is shipped with Import Map enabled. 
 
 Chromium based browsers does ship support for Import Maps as an [experimental feature](https://www.chromestatus.com/feature/5315286962012160) which has to be turned on by enabling the Experimental Productivity Features flag in Chromium based browsers:
 

--- a/docs/mapping_import_map.md
+++ b/docs/mapping_import_map.md
@@ -8,7 +8,7 @@ A key concept in Eik is to align the dependents of a module to the same version.
 
 Import Maps are a fairly new concept and will hopefully be supported in browsers in the close future. Import Maps allow [ECMA Script Modules (ESM)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) "bare" import specifiers, such as `import {html, render} from 'lit-html'` which will throw when used in a browser, to work by being mapped to a relative or absolute URLs the browser can use to load the module.
 
-In other words; in a ESM we can import a module like so:
+In other words; in an ESM we can import a module like so:
 
 ```js
 import {html, render} from 'lit-html';

--- a/docs/mapping_import_map.md
+++ b/docs/mapping_import_map.md
@@ -36,6 +36,6 @@ import * as lit from 'https://cdn.eik-server.com/npm/lit-html/v1/lit-html.js'
 
 ## Choose a Strategy
 
-Browser support for Import Maps are currently (October 2020) limited. There are polyfills available for Import Maps and its fully possible to apply Import Map to modules ahead of time through build tools. Eik does not dictate which strategy, a polyfill or ahead of time, one use to append Import Maps to modules but its adviced that an organization align on the same strategy accross its teams.
+Browser support for Import Maps is currently (October 2020) limited. There are polyfills available for Import Maps and its fully possible to apply Import Map to modules ahead of time through build tools. Eik does not dictate which strategy, a polyfill or ahead of time, one uses to append Import Maps to modules but its advised that an organization aligns on the same strategy across its teams.
 
 It is also worth keeping in mind that one are not locked to one strategy forever. An Import Map used to apply mapping ahead of time will work as intended in browsers the day there is full browser support for Import Maps.

--- a/docs/mapping_import_map.md
+++ b/docs/mapping_import_map.md
@@ -4,7 +4,7 @@ title: Import Map
 sidebar_label: Import Map
 ---
 
-A key concept in Eik is to align dependents of a module to the same version. A part of this concept is [Import Maps](https://github.com/WICG/import-maps) which make it possible to map import statements in modules.
+A key concept in Eik is to align the dependents of a module to the same version. A part of this concept is [Import Maps](https://github.com/WICG/import-maps) which makes it possible to map import statements in modules.
 
 Import Maps are a fairly new concept and will hopefully be supported in browsers in close future. Import Maps allow [ECMA Script Modules (ESM)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) "bare" import specifiers, such as `import {html, render} from 'lit-html'` which will throw when used in a browser, to work by being mapped to relative or abosulte URLs the browser can use to load the module.
 

--- a/docs/mapping_import_map.md
+++ b/docs/mapping_import_map.md
@@ -6,7 +6,7 @@ sidebar_label: Import Map
 
 A key concept in Eik is to align the dependents of a module to the same version. A part of this concept is [Import Maps](https://github.com/WICG/import-maps) which makes it possible to map import statements in modules.
 
-Import Maps are a fairly new concept and will hopefully be supported in browsers in close future. Import Maps allow [ECMA Script Modules (ESM)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) "bare" import specifiers, such as `import {html, render} from 'lit-html'` which will throw when used in a browser, to work by being mapped to relative or abosulte URLs the browser can use to load the module.
+Import Maps are a fairly new concept and will hopefully be supported in browsers in the close future. Import Maps allow [ECMA Script Modules (ESM)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) "bare" import specifiers, such as `import {html, render} from 'lit-html'` which will throw when used in a browser, to work by being mapped to a relative or absolute URLs the browser can use to load the module.
 
 In other words; in a ESM we can import a module like so:
 

--- a/docs/mapping_import_map.md
+++ b/docs/mapping_import_map.md
@@ -14,7 +14,7 @@ In other words; in an ESM we can import a module like so:
 import {html, render} from 'lit-html';
 ```
 
-Then an Import Map can be loaded as follow in the browser:
+Then an Import Map can be loaded as following in the browser:
 
 ```html
 <script type="importmap">

--- a/docs/mapping_import_map.md
+++ b/docs/mapping_import_map.md
@@ -1,0 +1,41 @@
+---
+id: mapping_import_map
+title: Import Map
+sidebar_label: Import Map
+---
+
+A key concept in Eik is to align dependents of a module to the same version. A part of this concept is [Import Maps](https://github.com/WICG/import-maps) which make it possible to map import statements in modules.
+
+Import Maps are a fairly new concept and will hopefully be supported in browsers in close future. Import Maps allow [ECMA Script Modules (ESM)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) "bare" import specifiers, such as `import {html, render} from 'lit-html'` which will throw when used in a browser, to work by being mapped to relative or abosulte URLs the browser can use to load the module.
+
+In other words; in a ESM we can import a module like so:
+
+```js
+import {html, render} from 'lit-html';
+```
+
+Then an Import Map can be loaded as follow in the browser:
+
+```html
+<script type="importmap">
+{
+  "imports": {
+    "lit-html": "https://cdn.eik-server.com/npm/lit-html/v1/lit-html.js",
+  }
+}
+</script>
+```
+
+When the Import Map is applied, our code will act as we have written:
+
+```js
+import {html, render} from 'lit-html';
+
+import * as lit from 'https://cdn.eik-server.com/npm/lit-html/v1/lit-html.js'
+```
+
+## Choose a Strategy
+
+Browser support for Import Maps are currently (October 2020) limited. There are polyfills available for Import Maps and its fully possible to apply Import Map to modules ahead of time through build tools. Eik does not dictate which strategy, a polyfill or ahead of time, one use to append Import Maps to modules but its adviced that an organization align on the same strategy accross its teams.
+
+It is also worth keeping in mind that one are not locked to one strategy forever. An Import Map used to apply mapping ahead of time will work as intended in browsers the day there is full browser support for Import Maps.

--- a/docs/mapping_import_map.md
+++ b/docs/mapping_import_map.md
@@ -38,4 +38,4 @@ import * as lit from 'https://cdn.eik-server.com/npm/lit-html/v1/lit-html.js'
 
 Browser support for Import Maps is currently (October 2020) limited. There are polyfills available for Import Maps and its fully possible to apply Import Map to modules ahead of time through build tools. Eik does not dictate which strategy, a polyfill or ahead of time, one uses to append Import Maps to modules but its advised that an organization aligns on the same strategy across its teams.
 
-It is also worth keeping in mind that one are not locked to one strategy forever. An Import Map used to apply mapping ahead of time will work as intended in browsers the day there is full browser support for Import Maps.
+It is also worth keeping in mind that one is not locked to one strategy forever. An Import Map used to apply mapping ahead of time will work as intended in browsers the day there is full browser support for Import Maps.

--- a/docs/mapping_plugins.md
+++ b/docs/mapping_plugins.md
@@ -4,7 +4,7 @@ title: Build Tool Plugins
 sidebar_label: Build Tool Plugins
 ---
 
-Eik provide a set of build tool plugins which cater for applying Import Maps ahead of time. 
+Eik provides a set of build tool plugins that cater for applying Import Maps ahead of time. 
 
 The common functionallity of these plugins is that they will, if found, load the `eik.json` in a project and fetch the defined Import Maps and then apply these to the code the build tool is processing.
 

--- a/docs/mapping_plugins.md
+++ b/docs/mapping_plugins.md
@@ -8,7 +8,7 @@ Eik provides a set of build tool plugins that cater for applying Import Maps ahe
 
 The common functionallity of these plugins is that they will, if found, load the `eik.json` in a project and fetch the defined Import Maps and then apply these to the code the build tool is processing.
 
-When using a build tool to apply an Import Map ahead of time, the build process should be run before a module is published to a Eik server.
+When using a build tool to apply an Import Map ahead of time, the build process should be run before a module is published to an Eik server.
 
 ## Available plugins
 

--- a/docs/mapping_plugins.md
+++ b/docs/mapping_plugins.md
@@ -1,0 +1,19 @@
+---
+id: mapping_plugins
+title: Build Tool Plugins
+sidebar_label: Build Tool Plugins
+---
+
+Eik provide a set of build tool plugins which cater for applying Import Maps ahead of time. 
+
+The common functionallity of these plugins is that they will, if found, load the `eik.json` in a project and fetch the defined Import Maps and then apply these to the code the build tool is processing.
+
+When using a build tool to apply an Import Map ahead of time, the build process should be run before a module is published to a Eik server.
+
+## Available plugins
+
+The following build tool plugins are available:
+
+ - [Rollup](https://github.com/eik-lib/import-map-rollup-plugin)
+ - [PostCSS](https://github.com/eik-lib/import-map-postcss-plugin)
+ 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -104,7 +104,7 @@ In each application we can now depend on and install lit-html through NPM as is 
 import {html, render} from 'lit-html'
 ```
 
-In the build tool used by the applications we can now add the appropiate Eik mapping utility which will read a set of defined Import Maps (in our example, "site-mapping") from the Eik server and apply these Import Maps to the application code. This will map our bare import statements into legal ESM import statements pointing to the lit-html alias defined in the Import Map:
+In the build tool used by the applications we can now add the appropriate Eik mapping utility which will read a set of defined Import Maps (in our example, "site-mapping") from the Eik server and apply these Import Maps to the application code. This will map our bare import statements into legal ESM import statements pointing to the lit-html alias defined in the Import Map:
 
 ```js
 import * as lit from '/npm/lit-html/v1/lit-html.js';

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -63,7 +63,7 @@ In Eik, we utilize bare imports to align modules (ex; the applications in our ex
 
 ## Import Maps
 
-[Import Maps](https://github.com/WICG/import-maps) are a fairly new and up and coming web standard. An Import Map is a simple object mapping between a bare import statement and a legal ESM import statement. The idea is that an Import Map should be used to map bare import statements to fully qualified import statements in ESM.
+[Import Maps](https://github.com/WICG/import-maps) is fairly new and up and coming web standard. An Import Map is a simple object mapping between a bare import statement and a legal ESM import statement. The idea is that an Import Map should be used to map bare import statements to fully qualified import statements in ESM.
 
 An Import Map looks something like this:
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -110,6 +110,6 @@ In the build tool used by the applications we can now add the appropriate Eik ma
 import * as lit from '/npm/lit-html/v1/lit-html.js';
 ```
 
-Now our application defines an ESM import statement that points to the alias for lit-html which makes sure multiple applications on our site align to the same version of lit-html. By doing this, we're able to develop our application in isolation without depending or interfering with any other applications that utilise the same library.
+Now our application defines an ESM import statement that points to the alias for lit-html which makes sure multiple applications on our site align to the same version of lit-html. By doing this, we're able to develop our application in isolation without depending or interfering with any other applications that utilize the same library.
 
 The final step in this process is uploading the application code as a package to the Eik server. Which is done by the Eik client.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -63,14 +63,14 @@ In Eik, we utilize bare imports to align modules (ex; the applications in our ex
 
 ## Import Maps
 
-Import Maps are a fairly new and up and coming web standard. An Import Map is a simple object mapping between a bare import statement and a legal ESM import statement. The idea is that an Import Map should be used to map bare import statements to fully qualified import statements in ESM.
+[Import Maps](https://github.com/WICG/import-maps) are a fairly new and up and coming web standard. An Import Map is a simple object mapping between a bare import statement and a legal ESM import statement. The idea is that an Import Map should be used to map bare import statements to fully qualified import statements in ESM.
 
 An Import Map looks something like this:
 
 ```json
 {
     "my_library": "https://eik-server.com/pkg/mylib/v3/main.js",
-    "lit-html": "https://eik-server.com/npm/lit-html/v1/"
+    "lit-html": "https://eik-server.com/npm/lit-html/v1/lit-html.js"
 }
 ```
 
@@ -92,7 +92,7 @@ Next, we need to create a mapping between the bare import statement developers w
 
 ```json
 {
-    "lit-html": "/npm/lit-html/v1"
+    "lit-html": "/npm/lit-html/v1/lit-html.js"
 }
 ```
 
@@ -101,13 +101,13 @@ Once created, we publish this Import Map to our Eik server and then create an al
 In each application we can now depend on and install lit-html through NPM as is common practice. Each application can then locally reference lit-html through its bare import statement like so:
 
 ```js
-import * as lit from 'lit-html';
+import {html, render} from 'lit-html'
 ```
 
 In the build tool used by the applications we can now add the appropiate Eik mapping utility which will read a set of defined Import Maps (in our example, "site-mapping") from the Eik server and apply these Import Maps to the application code. This will map our bare import statements into legal ESM import statements pointing to the lit-html alias defined in the Import Map:
 
 ```js
-import * as lit from '/npm/lit-html/v1';
+import * as lit from '/npm/lit-html/v1/lit-html.js';
 ```
 
 Now our application defines an ESM import statement that points to the alias for lit-html which makes sure multiple applications on our site align to the same version of lit-html. By doing this, we're able to develop our application in isolation without depending or interfering with any other applications that utilise the same library.

--- a/sidebars.js
+++ b/sidebars.js
@@ -4,6 +4,11 @@ module.exports = {
     Overview: [
       'overview'
     ],
+    Mapping: [
+      'mapping_import_map',
+      'mapping_browser',
+      'mapping_plugins'
+    ],
     Client: [
       'client_installation',
       'client_login',


### PR DESCRIPTION
This ads a section on mapping modules. It does more or less try to explain what Import Maps are and how they are to be applied. It give a small insight into the future where its possible to use import maps in the browser and also give us a location to list the different build tool plugins we will create to support ahead of time processing of import maps.