### PR TITLE
docs: update doc pages to reflect changes in v2

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -12,7 +12,7 @@ The process for publishing new asset versions from CI is as follows:
 
 1. Login to the Eik server
 1. Run the `eik version` command
-2. Run the `eik package` command
+2. Run the `eik publish` command
 3. Commit new version change to `eik.json`
 4. Push the change back to the repository
 

--- a/docs/client.md
+++ b/docs/client.md
@@ -27,7 +27,13 @@ See [the server docs](/docs/server)
 
 Set the `files` property of `eik.json` with paths to client side
 asset files in your project relative to the `eik.json` file.
-Eg. if you have a `scripts.js` file in an assets directory, the `js.input` value will be `assets/scripts.js`
+Eg. if you have files to include in an `assets` directory, you could set the `files` value to be `assets`
+
+```json
+{
+  "files": "assets"
+}
+```
 
 ### Step 2
 
@@ -165,16 +171,16 @@ eik meta lodash 4.17.16
 
 ### Command Summary
 
-| command    | aliases | description                                                     |
-| ---------- | ------- | --------------------------------------------------------------- |
-| init       | i       | Create an eik.json file in the current directory             |
-| login      |         | Authenticates client with eik server                            |
-| ping       |         | Pings eik server                                                |
-| publish    | p, pub  | Publish an app bundle                                           |
-| dependency | d, dep  | Publish a dependency bundle                                     |
-| map        | m       | Sets or deletes a "bare" import entry in an import-map file     |
-| alias      | a       | Sets a major semver alias for a given dependency or map         |
-| meta       | show    | Retrieves meta information for a package                        |
+| command    | aliases | description                                                 |
+| ---------- | ------- | ----------------------------------------------------------- |
+| init       | i       | Create an eik.json file in the current directory            |
+| login      |         | Authenticates client with eik server                        |
+| ping       |         | Pings eik server                                            |
+| publish    | p, pub  | Publish an app bundle                                       |
+| dependency | d, dep  | Publish a dependency bundle                                 |
+| map        | m       | Sets or deletes a "bare" import entry in an import-map file |
+| alias      | a       | Sets a major semver alias for a given dependency or map     |
+| meta       | show    | Retrieves meta information for a package                    |
 
 ### Commands Overview
 
@@ -202,13 +208,14 @@ You will then need to set the various fields as appropriate. If you are running 
 
 ##### eik.json properties
 
-| property     | description                                                         |
-| ------------ | ------------------------------------------------------------------- |
-| name         | App name, must be unique to the Eik server                          |
-| server       | Address to the asset server                                         |
-| js           | Configuration for JavaScript assets                                 |
-| css          | Configuration for CSS assets                                        |
-| import-map   | Specify import maps to be used to map bare imports during bundling  |
+| property   | description                                                            |
+| ---------- | ---------------------------------------------------------------------- |
+| name       | App name, must be unique to the Eik server                             |
+| type       | Package type. Can be "package", "npm", or "map", defaults to "package" |
+| server     | Address to the asset server                                            |
+| js         | Configuration for JavaScript assets                                    |
+| css        | Configuration for CSS assets                                           |
+| import-map | Specify import maps to be used to map bare imports during bundling     |
 
 ###### name
 
@@ -218,6 +225,16 @@ Names may contain any letters or numbers as well as the `-` and `_` characters.
 ```json
 {
   "name": "my-awesome-app"
+}
+```
+
+###### type
+
+Changes what namespace that a package is published under. Applications should use "package" (the default). When mirroring packages from the NPM repository, use "npm". Import maps use "map".
+
+```json
+{
+  "type": "package"
 }
 ```
 
@@ -430,14 +447,14 @@ const result = await new cli.Init(options).run();
 
 #### options
 
-| name    | description                           | type   | default         | required |
-| ------- | ------------------------------------- | ------ | --------------- | -------- |
-| logger  | log4j compliant logger object         | object | `null`          | no       |
-| cwd     | path to current working directory     | string | `process.cwd()` | no       |
-| name    | app name                              | string | `''`            | no       |
-| server  | URL to asset server                   | string | `''`            | no       |
-| js      | path to client side script entrypoint | string | `''`            | no       |
-| css     | path to client side style entrypoint  | string | `''`            | no       |
+| name   | description                           | type   | default         | required |
+| ------ | ------------------------------------- | ------ | --------------- | -------- |
+| logger | log4j compliant logger object         | object | `null`          | no       |
+| cwd    | path to current working directory     | string | `process.cwd()` | no       |
+| name   | app name                              | string | `''`            | no       |
+| server | URL to asset server                   | string | `''`            | no       |
+| js     | path to client side script entrypoint | string | `''`            | no       |
+| css    | path to client side style entrypoint  | string | `''`            | no       |
 
 ### publish
 
@@ -448,16 +465,16 @@ const result = await new cli.publish.App(options).run();
 
 #### options
 
-| name    | description                           | type     | default         | required |
-| ------- | ------------------------------------- | -------- | --------------- | -------- |
-| logger  | log4j compliant logger object         | object   | `null`          | no       |
-| cwd     | path to current working directory     | string   | `process.cwd()` | no       |
-| name    | app name                              | string   |                 | yes      |
-| server  | URL to asset server                   | string   |                 | yes      |
-| js      | path to client side script entrypoint | string   |                 | yes      |
-| css     | path to client side style entrypoint  | string   |                 | yes      |
-| map     | array of urls of import map files     | string[] | `[]`            | no       |
-| dryRun  | exit early and print results          | boolean  | false           | no       |
+| name   | description                           | type     | default         | required |
+| ------ | ------------------------------------- | -------- | --------------- | -------- |
+| logger | log4j compliant logger object         | object   | `null`          | no       |
+| cwd    | path to current working directory     | string   | `process.cwd()` | no       |
+| name   | app name                              | string   |                 | yes      |
+| server | URL to asset server                   | string   |                 | yes      |
+| js     | path to client side script entrypoint | string   |                 | yes      |
+| css    | path to client side style entrypoint  | string   |                 | yes      |
+| map    | array of urls of import map files     | string[] | `[]`            | no       |
+| dryRun | exit early and print results          | boolean  | false           | no       |
 
 ### dependency
 
@@ -468,14 +485,14 @@ const result = await new cli.publish.Dependency(options).run();
 
 #### options
 
-| name    | description                       | type     | default         | required |
-| ------- | --------------------------------- | -------- | --------------- | -------- |
-| logger  | log4j compliant logger object     | object   | `null`          | no       |
-| cwd     | path to current working directory | string   | `process.cwd()` | no       |
-| name    | app name                          | string   |                 | yes      |
-| server  | URL to asset server               | string   |                 | yes      |
-| map     | array of urls of import map files | string[] | `[]`            | no       |
-| dryRun  | exit early and print results      | boolean  | false           | no       |
+| name   | description                       | type     | default         | required |
+| ------ | --------------------------------- | -------- | --------------- | -------- |
+| logger | log4j compliant logger object     | object   | `null`          | no       |
+| cwd    | path to current working directory | string   | `process.cwd()` | no       |
+| name   | app name                          | string   |                 | yes      |
+| server | URL to asset server               | string   |                 | yes      |
+| map    | array of urls of import map files | string[] | `[]`            | no       |
+| dryRun | exit early and print results      | boolean  | false           | no       |
 
 ### map
 
@@ -504,13 +521,13 @@ const result = await new cli.Alias(options).run();
 
 #### options
 
-| name    | description                             | type   | default | choices      | required |
-| ------- | --------------------------------------- | ------ | ------- | ------------ | -------- |
-| logger  | log4j compliant logger object           | object | `null`  |              | no       |
-| server  | URL to asset server                     | string |         |              | yes      |
-| type    | type of resource to alias               | string |         | `pkg`, `map` | yes      |
-| name    | app name                                | string |         |              | yes      |
-| alias   | major number of a semver version number | string |         |              | yes      |
+| name   | description                             | type   | default | choices      | required |
+| ------ | --------------------------------------- | ------ | ------- | ------------ | -------- |
+| logger | log4j compliant logger object           | object | `null`  |              | no       |
+| server | URL to asset server                     | string |         |              | yes      |
+| type   | type of resource to alias               | string |         | `pkg`, `map` | yes      |
+| name   | app name                                | string |         |              | yes      |
+| alias  | major number of a semver version number | string |         |              | yes      |
 
 ### meta
 
@@ -519,8 +536,8 @@ const cli = require("@eik/cli");
 const result = await new cli.Meta(options).run();
 ```
 
-| name    | description                   | type   | default | choices | required |
-| ------- | ----------------------------- | ------ | ------- | ------- | -------- |
-| logger  | log4j compliant logger object | object | `null`  |         | no       |
-| server  | URL to asset server           | string |         |         | yes      |
-| name    | package name                  | string |         |         | yes      |
+| name   | description                   | type   | default | choices | required |
+| ------ | ----------------------------- | ------ | ------- | ------- | -------- |
+| logger | log4j compliant logger object | object | `null`  |         | no       |
+| server | URL to asset server           | string |         |         | yes      |
+| name   | package name                  | string |         |         | yes      |

--- a/docs/client_aliases.md
+++ b/docs/client_aliases.md
@@ -40,7 +40,7 @@ After publishing a new version of a package `1.0.1`
 
 ```sh
 eik version patch
-eik package
+eik publish
 ```
 
 The alias can then be updated with the same alias command as before giving it the newly published version
@@ -55,7 +55,7 @@ And now `v1` will point to `1.0.1` instead of `1.0.0`
 
 ### Using an aliased version
 
-Creating aliases for NPM packages that have an Eik mirror allows you to include the alias script tags in your application without needing to update the script tag every time you publish a new bundle version.
+Creating aliases for NPM scoped packages allows you to include the alias script tags in your application without needing to update the script tag every time you publish a new bundle version.
 
 ```js
 <script type="module" defer src="https://myeikserver.com/npm/lodash/v4/index.js">
@@ -75,13 +75,7 @@ eik npm-alias lodash 4.17.18 4
 
 ### Updating an alias
 
-After publishing a new version of the NPM package
-
-```sh
-eik npm lodash 4.17.19
-```
-
-The alias can then be updated with the same alias command as before giving it the newly published version
+After publishing a new version of an NPM scoped package, the alias can then be updated with the same alias command as before giving it the newly published version
 
 ```sh
 eik npm-alias lodash 4.17.19 4
@@ -109,13 +103,7 @@ eik map-alias my-map 1.0.0 1
 
 ### Updating an alias
 
-After publishing a new version of an import map
-
-```sh
-eik map my-map 1.0.1 ./import-map.json
-```
-
-The alias can then be updated with the same alias command as before giving it the newly published version
+After publishing a new version of an import map, the alias can then be updated with the same alias command as before giving it the newly published version
 
 ```sh
 eik map-alias my-map 1.0.1 1

--- a/docs/client_app_packages.md
+++ b/docs/client_app_packages.md
@@ -8,7 +8,7 @@ Publishing and serving your application's client side assets is the main task Ei
 
 ## Producing packages
 
-Use the `package` command to package and upload local JavaScript and CSS bundle files to an Eik server from where they will be served.
+Use the `publish` command to package and upload local JavaScript and CSS bundle files to an Eik server from where they will be served.
 
 ### eik.json definitions
 
@@ -18,12 +18,7 @@ In your app's Eik config you use the `files` key to define local file paths to b
 
 ```json
 {
-    "files": {
-        "./scripts.js": "./scripts.js",
-        "./scripts.js.map": "./scripts.js.map",
-        "./styles.css": "./styles.css",
-        "./styles.css.map": "./styles.css.map",
-    }
+    "files": "./scripts"
 }
 ```
 
@@ -32,79 +27,86 @@ In your app's Eik config you use the `files` key to define local file paths to b
 ```json
 {
     "eik": {
-        "files": {
-            "./scripts.js": "./scripts.js",
-            "./scripts.js.map": "./scripts.js.map",
-            "./styles.css": "./styles.css",
-            "./styles.css.map": "./styles.css.map",
-        }
+        "files": "./scripts"
     }
 }
 ```
 
 ### The publish command
 
-With entrypoints defined in the Eik config, running the `eik package` command will assemble files (specified by entrypoints) into an archive and upload the archive to the Eik server defined by the `server` field.
+With entrypoints defined in the Eik config, running the `eik publish` command will assemble files (specified by entrypoints) into an archive and upload the archive to the Eik server defined by the `server` field.
 
 ```sh
-eik package
+eik publish
 ```
 
 Once uploaded, the archive will be unpacked and the files served at the appropriate paths.
 
-The following example shows how entrypoint definitions correspond to final file locations:
+The following examples show how entrypoint definitions correspond to final file locations:
 
 #### Example.
 
-*Either in eik.json define...*
+```js
+// everything in the `<cwd>/folder` is uploaded to /
+files: 'folder'
 
-```json
-{
-    "server": "http://assets.myserver.com",
-    "name": "my-pack",
-    "version": "1.0.0",
-    "files": {
-        "index.js": "./scripts.js",
-        "index.js.map": "./scripts.js.map",
-        "ie11.js": "./scripts-fallback.js",
-        "ie11.js.map": "./scripts-fallback.js.map",
-        "index.css": "./styles.css",
-        "index.css.map": "./styles.css.map"
-    }
+// everything in the `<cwd>/folder` is uploaded to /
+files: './folder'
+
+// everything in the `<cwd>/folder` is uploaded to /
+files: './folder/'
+
+// everything in the `<cwd>/folder/nested` is uploaded to /
+files: './folder/nested'
+
+// everything in the `<cwd>/folder` is uploaded to / (no directory recursion)
+files: './folder/*'
+
+// everything in the `<cwd>` is uploaded to / (dont do this!)
+files: './**/*'
+
+// everything in the `<cwd>/folder` is uploaded to /
+files: './folder/**/*'
+
+// everything in the `/path/to/folder` is uploaded to /
+files: '/path/to/folder/**/*'
+
+// everything in the `/path/to/folder` is uploaded to /
+files: '/path/to/folder'
+
+files: {
+    // file `<cwd>/path/to/esm.js` is uploaded and renamed to `/script.js`
+    'script.js': './path/to/esm.js',
+
+    // file `/absolute/path/to/esm.js` is uploaded and renamed to `/script.js` 
+    'script.js': '/absolute/path/to/esm.js',
+
+    // everything inside `/absolute/path/to/folder` is uploaded to `/folder`
+    'folder': '/absolute/path/to/folder',
+
+    // everything in `<cwd>/path/to/folder` is uploaded to `/folder`
+    'folder': './path/to/folder',
+
+    // everything in `<cwd>/path/to/folder` is uploaded to `/folder`
+    'folder': 'path/to/folder',
+
+    // everything in `/absolute/path/to/folder` is uploaded to `/folder`
+    'folder': '/absolute/path/to/folder/**/*',
+
+    // everything in `<cwd>/path/to/folder` is uploaded to `/folder` (but no folder recursion)
+    'folder': './path/to/folder/*',
+
+    // everything in `<cwd>/path/to/folder` is uploaded to `/folder`
+    'folder': 'path/to/folder/**/*',
+
+    // everything in `<cwd>/path/to/folder` is uploaded to `/folder/scripts`
+    'folder/scripts': 'path/to/folder/**/*',
 }
 ```
 
-*or in package.json define...*
-
-```json
-{
-    "eik": {
-        "name": "my-pack",
-        "version": "1.0.0",
-        "server": "http://assets.myserver.com",
-        "files": {
-            "index.js": "./scripts.js",
-            "index.js.map": "./scripts.js.map",
-            "ie11.js": "./scripts-fallback.js",
-            "ie11.js.map": "./scripts-fallback.js.map",
-            "index.css": "./styles.css",
-            "index.css.map": "./styles.css.map"
-        }
-    }
-}
-```
-
-*then run the command...*
-
-```sh
-eik package
-```
-
-*URLs after packaging will be...*
+*URLs after uploading will be something like...*
 
 * `http://assets.myserver.com/pkg/my-pack/1.0.0/index.js`
 * `http://assets.myserver.com/pkg/my-pack/1.0.0/index.js.map`
-* `http://assets.myserver.com/pkg/my-pack/1.0.0/ie11.js`
-* `http://assets.myserver.com/pkg/my-pack/1.0.0/ie11.js.map`
 * `http://assets.myserver.com/pkg/my-pack/1.0.0/index.css`
 * `http://assets.myserver.com/pkg/my-pack/1.0.0/index.css.map`

--- a/docs/client_import_maps.md
+++ b/docs/client_import_maps.md
@@ -23,7 +23,7 @@ An import like this has no meaning and your browser will not know what to do wit
 
 ## About import maps
 
-Import maps are an [emerging standard](https://github.com/WICG/import-maps) that allow control over what URLs get fetched by JavaScript import statements and import() expressions allowing "bare import specifiers", such as `import moment from "moment"`, to work in the browser (without a build step). By following this emerging standard, it will eventually be possible to use import maps in Eik apps without the need to support them during bundling. For now, however, it is necessary to use a plugin such as `rollup-plugin-eik-import-maps` when bundling to replace "bare imports" with values in import map files.
+Import maps are an [emerging standard](https://github.com/WICG/import-maps) that allow control over what URLs get fetched by JavaScript import statements and import() expressions allowing "bare import specifiers", such as `import moment from "moment"`, to work in the browser (without a build step). By following this emerging standard, it will eventually be possible to use import maps in Eik apps without the need to support them during bundling. For now, however, it is necessary to use a plugin such as `@eik/rollup-plugin` when bundling to replace "bare imports" with values in import map files.
 
 ## Example use cases
 
@@ -35,7 +35,7 @@ For an organisation with many web applications, each with a lot of pages, all us
 
 An import map is just a JSON file that's served at a specific URL. Eik includes support for uploading and versioning import maps.
 
-If we create an import map JSON file named `import-map.json` with the following contents:
+If we create an import map JSON file named `import-map.json` with the following content:
 
 ```json
 {
@@ -53,7 +53,7 @@ We can publish it to an Eik server with the following command:
 eik map my-map 1.0.0 ./import-map.json
 ```
 
-Each import map is uniquely identified by a name and a version and will be uploaded and then served by the Eik server at a path of the form `/map/<name>/<version>` so in the case above, the import map will be published to `/map/my-map/1.0.0` on the Eik server. We can publish updates simply by specifying a newer version that any previously published. Eg. `1.0.1`.
+Each import map is uniquely identified by a name and a version and will be uploaded and then served by the Eik server at a path of the form `/map/<name>/<version>` so in the case above, the import map will be published to `/map/my-map/1.0.0` on the Eik server. We can publish updates simply by specifying a newer version than any previously published. Eg. `1.0.1`.
 
 ## Using published import maps
 
@@ -97,7 +97,7 @@ import React from 'https://assets.myeikserver.com/npm/react/16.17.4/index.js';
 
 We currently support the following plugins
 
-* Rollup: [@eik/rollup-plugin-import-map](https://github.com/eik-lib/rollup-plugin-import-map)
+* Rollup: [@eik/rollup-plugin](https://github.com/eik-lib/rollup-plugin)
 
 ## Usage with Aliases
 

--- a/docs/client_installation.md
+++ b/docs/client_installation.md
@@ -4,7 +4,7 @@ title: Client Installation
 sidebar_label: Installation
 ---
 
-In order to interact with an Eik server, you must install the client which can then be used to perform a variety of tasks such as mirroring NPM packages, publishing app packages, aliasing, publishing import maps and more. Interacting with the client is done via the command line in a terminal. To get started, you will need to have [Node.js](https://nodejs.org/en/) installed which comes with the [NPM](https://npmjs.com) package manager.
+In order to interact with an Eik server, you must install the client which can then be used to perform a variety of tasks such as publishing app packages, aliasing, publishing import maps and more. Interacting with the client is done via the command line in a terminal. To get started, you will need to have [Node.js](https://nodejs.org/en/) (version 12 or greater) installed which comes with the [NPM](https://npmjs.com) package manager.
 
 *N.B.* To use the client, you will need to know the address of an Eik server with which to interact. If you don't yet have a server to work with, please visit [the server docs](/docs/server) to get started configuring and running an Eik server.
 

--- a/docs/client_login.md
+++ b/docs/client_login.md
@@ -40,11 +40,5 @@ eik login --server https://assets.myeikserver2.com --key ######
 So long as the client is logged in to a single server, all subsequent commands will know which server to use and provide credentials automatically.
 
 ```sh
-eik npm lodash
-```
-
-*N.B.* If the client is authenticated with more than one server, it may be necessary to tell the client which server to use when using commands since the client will not decide which authenticated server to give precedence to. The `--server` (or `-s` for short) flag can be used to do this.
-
-```sh
-eik npm lodash --server https://assets.myeikserver.com
+eik publish
 ```

--- a/docs/client_npm_packages.md
+++ b/docs/client_npm_packages.md
@@ -1,51 +1,29 @@
 ---
 id: client_npm_packages
-title: ESM Friendly NPM Packages
-sidebar_label: NPM Packages
+title: NPM scoped Packages
+sidebar_label: NPM Scoped Packages
 ---
 
-One task Eik can perform is to take packages that have been published to NPM and create and serve ESM friendly versions for you to use in your app packages.
-
-This is similar to what [unpkg](https://unpkg.com/) and [pika](https://www.pika.dev/) do except that Eik will automatically transpile [common js](https://en.wikipedia.org/wiki/CommonJS) packages into an ESM version (as well as a fallback version for older browsers) before serving.
+One task you may wish to perform is to take packages that have been published to NPM and create and serve ESM friendly versions for use as across your team or organisation.
 
 When combined with Eik's aliasing feature, this gives you a powerful way to manage dependency versions across multiple applications.
 
-## The eik npm command
+## The eik type field
 
-To view subcommands and additional help in your terminal you can use
+The only difference from publishing application packages is the use of an `npm` namespace which can be set using the `type` field in `eik.json` or the `package.json` `eik` field.
 
-```sh
-eik npm --help
+```json
+{
+    "type": "npm"
+}
 ```
 
-## Publishing from NPM
+## Publishing
 
-As an example of how this works, let's publish a version of the popular `lodash` package to Eik.
+Once the type field has been set, simply run the `eik publish` command as you would usually.
 
-### Install a specific version 
-
-Call the command with the name and version of the package you want to install from NPM.
-
-```sh
-eik npm lodash 4.17.15
 ```
-
-### Install the latest version
-
-It's possible to omit the version argument to get the latest available version on NPM.
-
-```sh
-eik npm lodash
-```
-
-## Accessing installed NPM packages
-
-### The Eik meta command
-
-To view publish information, you can use the `eik meta` command.
-
-```sh
-eik meta lodash
+eik publish
 ```
 
 ### Server URLs

--- a/docs/client_putting_it_all_together.md
+++ b/docs/client_putting_it_all_together.md
@@ -10,13 +10,9 @@ In the following example, the `@podium/browser` package will be set up as a depe
 
 ## Publish from NPM
 
-Publish an Eik mirror of the NPM package `@podium/browser`. Eik installs a local copy of the module, bundles it into a single ESM friendly file and uploads it to an Eik server ready for use.
+Publish a version of `@podium/browser` to your Eik server using the `npm` namespace. The process for this is essentially the same as for any other package that you publish except for that you should set the `eik.json` file's `type` field to `npm`.
 
-```sh
-eik npm @podium/browser 1.0.0-beta.2
-```
-
-`@podium/browser` should now be available at `https://myeikserver.com/npm/@podium/browser/1.0.0-beta.2/index.js`
+Once you have done this, you should have a version of `@podium/browser` available at a URL similar to `https://myeikserver.com/npm/@podium/browser/1.0.0-beta.2/index.js`
 
 ## Alias NPM package
 
@@ -67,11 +63,9 @@ eik.json
 {
     "server": "https://myeikserver.com",
     "name": "my-app",
+    "type": "package",
     "version": "1.0.0",
-    "files": {
-        "./esm.js": "./bundle.js",
-        "./esm.js.map": "./bundle.js.map",
-    },
+    "files": "./dist",
     "import-map": "https://myeikserver.com/map/my-map/v1"
 }
 ```
@@ -80,22 +74,22 @@ eik.json
 
 This assumes you are already familiar with using Rollup and the instructions here only show how to augment an existing setup.
 
-Add `@eik/rollup-plugin-import-map` to your rollup config file
+Add `@eik/rollup-plugin` to your rollup config file
 
 ```sh
-npm install -D @eik/rollup-plugin-import-map
+npm install -D @eik/rollup-plugin
 ```
 
 ```js
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import babel from '@rollup/plugin-babel';
-import eik from '@eik/rollup-plugin-import-map';
+import eik from '@eik/rollup-plugin';
 
 export default {
     input: './src/index.js',
     output: {
-        file: './bundle.js',
+        file: './dist/bundle.js',
         format: 'es',
         sourcemap: true,
     },
@@ -108,12 +102,10 @@ export default {
 };
 ```
 
-*n.b.* The `js` field in `eik.json` is set to read `bundle.js` which is produced by the rollup build.
-
 ## publish bundled code to Eik server
 
 ```sh
-eik package
+eik publish
 ```
 
 ## Consuming an application bundle
@@ -121,7 +113,7 @@ eik package
 The application bundle can be included in an HTML page using a script tag like so
 
 ```html
-<script src="https://myeikserver.com/pkg/my-app/1.0.0/esm.js" type="module" defer></script>
+<script src="https://myeikserver.com/pkg/my-app/1.0.0/bundle.js" type="module" defer></script>
 ```
 
 Any bare references to `@podium/browser` will have been replaced with absolute URLs to the Eik server.

--- a/docs/mapping_browser.md
+++ b/docs/mapping_browser.md
@@ -6,7 +6,7 @@ sidebar_label: Browser Support
 
 Eventually, browsers will support Import Maps but currently (October 2020) no browser is shipped with Import Map enabled. 
 
-Chromium based browsers does ship support for Import Maps as an [experimental feature](https://www.chromestatus.com/feature/5315286962012160) which has to be turned on by enabling the Experimental Productivity Features flag in Chromium based browsers:
+Chromium based browsers do ship support for Import Maps as an [experimental feature](https://www.chromestatus.com/feature/5315286962012160) which has to be turned on by enabling the Experimental Productivity Features flag in Chromium based browsers:
 
  - [Chrome](chrome://flags/#enable-experimental-productivity-features)
  - [Brave](brave://flags/#enable-experimental-productivity-features)

--- a/docs/mapping_import_map.md
+++ b/docs/mapping_import_map.md
@@ -36,4 +36,4 @@ Browser support for Import Maps is currently (October 2020) limited. There are p
 
 Eik does not dictate which strategy, a polyfill or ahead of time, is used for import mapping modules but we recommend that an organization aligns itself with the same strategy across its teams.
 
-It is also worth keeping in mind that one is not locked to one strategy forever. An Import Map used to apply mapping ahead of time will work as intended in browsers the day there is full browser support for Import Maps.
+It is also worth keeping in mind that there is no lock in here. An Import Map used to apply mapping ahead of time during bundling will also work as intended in browsers the day there is full browser support for Import Maps.

--- a/docs/mapping_plugins.md
+++ b/docs/mapping_plugins.md
@@ -6,7 +6,7 @@ sidebar_label: Build Tool Plugins
 
 Eik provides a set of build tool plugins that cater for applying Import Maps ahead of time. 
 
-The common functionallity of these plugins is that they will, if found, load the `eik.json` in a project and fetch the defined Import Maps and then apply these to the code the build tool is processing.
+The common functionallity of these plugins is that they will, if found, load the `eik.json` file in a project and fetch any defined Import Maps before applying the values within to the code the build tool is processing.
 
 When using a build tool to apply an Import Map ahead of time, the build process should be run before a module is published to an Eik server.
 
@@ -14,6 +14,7 @@ When using a build tool to apply an Import Map ahead of time, the build process 
 
 The following build tool plugins are available:
 
- - [Rollup](https://github.com/eik-lib/import-map-rollup-plugin)
- - [PostCSS](https://github.com/eik-lib/import-map-postcss-plugin)
+ - [Rollup](https://github.com/eik-lib/rollup-plugin)
+ - [ESBuild](https://github.com/eik-lib/esbuild-plugin)
+ - [PostCSS](https://github.com/eik-lib/postcss-plugin)
  

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -16,7 +16,7 @@ In a moderate or large sized web site it is very common that the site is built a
 
 Lets say we have a site where the front page (`site.com`) is one application. Then we have a web shop, a second application, on `site.com/shop` and finally there is a third application handling checkout on `site.com/checkout`. A user will normally arrive at the front page, move to browsing the shop and then finish at the checkout.
 
-Let's also say that all of these applications are using [lit-html](https://lit-html.polymer-project.org/) for templating in the browser. We then have different applications depending on the same library that we want to be developed and deployed to production autonomously. Problems can arise when some of these application start to depend on different versions of the same library.
+Let's also say that all of these applications are using [lit-html](https://lit-html.polymer-project.org/) for templating in the browser. We then have different applications depending on the same library that we want to be developed and deployed to production autonomously. Problems can arise when some of these applications start to depend on different versions of the same library.
 
 ![Non-optimised loading of assets](/img/overview_page_to_page_diff_versions.min.svg)
 
@@ -24,14 +24,14 @@ Our challenge is to avoid the end user having to end up downloading different ve
 
 ![Optimised loading of assets](/img/overview_page_to_page_same_versions.min.svg)
 
-The Eik solution is to make all applications point to the same version of the same library in production despite that the applications are developed using different patch or minor version. If the library then has appropriate HTTP cache headers, the browser will do the rest and make sure the library is loaded over the wire only once during the user's visit to our site.
+The Eik solution is to make all applications point to the same version of the same library in production despite the fact that the applications are developed using different patch or minor version. If the library then has appropriate HTTP cache headers, the browser will do the rest and make sure the library is loaded over the wire only once during the user's visit to our site.
 
 
 ## How Eik works
 
-The main role of the Eik server is to serve static assets uploaded to the server. Upon upload, assets will be given a new versioned pathname for each upload and are considered immutable. A change in an asset is a new version on the Eik server. By doing so, served assets can be cached forever in the end users browser.
+The main role of the Eik server is to serve static assets uploaded to it. Upon upload, assets will be given a new versioned pathname for each upload (assets at any given path are immutible and will never change). A change to an asset is published as a new version to a new URL on the Eik server. By doing this, served assets can be cached forever in the end users browser.
 
-The Eik server also has the concept called an alias. An alias is a non immutable pathname which can be set to redirect requests to it, to an immutable asset pathname. 
+The Eik server also has a concept called an alias. An alias is a non immutable pathname which can be set to redirect requests sent to it, to an immutable asset pathname. 
 
 For example, let us say that we upload lit-html version 1.1.1 to an Eik server. This version of lit-html will then live on the immutable URL `/npm/lit-html/1.1.1`. We can then set an alias for lit-html and this alias will be on the non immutable pathname `/npm/lit-html/v1`. Any request to any file under the alias at `/npm/lit-html/v1` will then be redirected to the matching file under `/npm/lit-html/1.1.1`.
 
@@ -69,7 +69,7 @@ In Eik, we utilize bare imports to align modules (ex; the applications in our ex
 
 ## Import Maps
 
-[Import Maps](https://github.com/WICG/import-maps) is fairly new and up and coming web standard. An Import Map is a simple object mapping between a bare import statement and a legal ESM import statement. The idea is that an Import Map should be used to map bare import statements to fully qualified import statements in ESM.
+[Import Maps](https://github.com/WICG/import-maps) are a fairly new and up and coming web standard. An Import Map is a simple object mapping between a bare import statement and a legal ESM import statement. The idea is that an Import Map should be used to map bare import statements to fully qualified import statements in ESM.
 
 An Import Map looks something like this:
 
@@ -82,7 +82,7 @@ An Import Map looks something like this:
 
 Eik has support for storing Import Maps under a dedicated namespace. Import Maps are versioned and immutable and can be aliased in the same way that assets can.
 
-Eik's mapping utils is used to apply Import Maps to assets during bundling.
+Eik's mapping utils are used to apply Import Maps to assets during bundling.
 
 ## Mapping it together
 

--- a/docs/overview_concepts.md
+++ b/docs/overview_concepts.md
@@ -46,7 +46,7 @@ A package intended to be published to an Eik server should follow the [NPM modul
     + favicon.ico
 - package name length cannot exceed 214
 
-All packages published to an Eik server is immutable and versioned with [Semantic Versioning](https://semver.org/). This makes it possible to differentiate between what are considered smaller changes to a package which should not break behaviour in a dependency from changes which can be breaking.
+All packages published to an Eik server are immutable and versioned with [Semantic Versioning](https://semver.org/). This makes it possible to differentiate between what are considered smaller changes to a package which should not break behaviour in a dependency from changes which can be breaking.
 
 Since packages are immutable, the Eik server will set an infinite HTTP cache control header on all files belonging to a package to make use of browser caching.
 
@@ -54,7 +54,7 @@ Since packages are immutable, the Eik server will set an infinite HTTP cache con
 
 Aliasing can be applied to all packages and is a way of having a static URL reference, which can change, to a version of a package. Aliases are mutable and can be set to point to different versions of a package. The alias URL will do a redirect to the full version that it is set to point to.
 
-Lets say we publish `lit-html`  version `1.1.1`  as an NPM package to an Eik server. It will then live on the following URL:
+Lets say we publish `lit-html`  version `1.1.1` as an NPM package to an Eik server. It will then live on the following URL:
 
 ```sh
 https://eik-server.com/npm/lit-html/1.1.1/

--- a/docs/overview_eik_json.md
+++ b/docs/overview_eik_json.md
@@ -4,11 +4,11 @@ title: The eik.json File
 sidebar_label: The eik.json File
 ---
 
-Eik packaging is configured either by way of a JSON meta file called `eik.json` or by values included in a `package.json` file. Any project that publishes assets to an Eik server must provide this configuration in one (and only one) of these locations.
+Eik packaging is configured either by way of a JSON meta file called `eik.json` or by values included in `package.json`. Any project that publishes assets to an Eik server must provide this configuration in one (and only one) of these ways.
 
 ### Defining Eik configuration in an eik.json file
 
-The most common way to configure an Eik setup is to create and populate an `eik.json` file in a project's root. Values placed in this configuration tell the Eik client where the Eik server is location, which files to package, name, version and so on.
+The most common way to configure an Eik setup is to create and populate an `eik.json` file in the project's root. Values placed in this configuration tell the Eik client where the Eik server is located, which files to package, its name, version and so on.
 
 __*Example*__
 
@@ -17,10 +17,7 @@ __*Example*__
   "name": "my-app",
   "version": "1.0.0",
   "server": "https://assets.myeikserver.com",
-  "files": {
-    "index.js": "./scripts.js",
-    "index.css": "./styles.css"
-  },
+  "files": "./dist",
   "import-map": "https://assets.myeikserver.com/map/my-map/1.0.0"
 }
 ```
@@ -37,16 +34,13 @@ __*Example*__
     "name": "my-app",
     "version": "1.0.0",
     "server": "https://assets.myeikserver.com",
-    "files": {
-      "index.js": "./scripts.js",
-      "index.css": "./styles.css"
-    },
+    "files": "./dist",
     "import-map": "https://assets.myeikserver.com/map/my-map/1.0.0"
   }
 }
 ```
 
-It is also possible to have Eik use the `package.json` `name` and `version` fields by omitting them from the configuration.
+It is also possible to have Eik use the `package.json` `name` and `version` fields by omitting them from the Eik configuration.
 
 __*Example*__
 
@@ -56,11 +50,7 @@ __*Example*__
   "version": "1.0.0",
   "eik": {
     "server": "https://assets.myeikserver.com",
-    "files": {
-      "index.js": "./scripts.js",
-      "index.css": "./styles.css"
-    },
-    "import-map": "https://assets.myeikserver.com/map/my-map/1.0.0"
+    "files": "./dist"
   }
 }
 ```
@@ -124,36 +114,50 @@ See the [server docs](/docs/server) for how to setup and configure an Eik server
 
 * required
 
-Defines JavaScript and CSS file entrypoints to publish. This can be a string defining a single entrypoint or it can be an object that maps publish paths to local file system file locations. 
+Defines JavaScript and CSS file entrypoints to publish. This can be a string defining a single entrypoint or folder, or it can be an object that maps publish paths to local file system file locations.
 
 See [application packages](/docs/client_app_packages) for more information.
 
+#### Entrypoint path
+
+The simplest way to specify files is with a path to a folder to upload. Everything within the folder will be uploaded as is and filenames will be preserved.
+
+If the following folder contains the files, `esm.js`, and `styles.css` then:
+
+```json
+{
+  "files": "path/to/files"
+}
+```
+
+will result in 3 files at the following locations:
+
+* `/pkg/<name>/<version>/eik.json`
+* `/pkg/<name>/<version>/esm.js`
+* `/pkg/<name>/<version>/styles.css`
+
 #### Entrypoint file mappings
 
-An object must be provided to define any number of JavaScript files to be included when publishing. Object keys define publish locations on the Eik server and object values define the local file entrypoint locations. This aligns somewhat loosely with [ESM package entrypoints](https://nodejs.org/dist/latest-v14.x/docs/api/esm.html#esm_package_entry_points) in Node.js
+Instead of a string, an object can be provided to define any number of JavaScript files to be included when publishing. Object keys define publish locations on the Eik server and object values define the local file entrypoint locations and may include globbing. This aligns somewhat loosely with [ESM package entrypoints](https://nodejs.org/dist/latest-v14.x/docs/api/esm.html#esm_package_entry_points) in Node.js
 
 The following defines several JavaScript and CSS entrypoints and their locations on the server where they will be published to. 
 
 ```json
 {
   "files": {
-    "./esm.js": "./esm.js",
-    "./esm.js.map": "./esm.js.map",
-    "./ie11.js": "./ie11.js",
-    "./ie11.js.map": "./ie11.js.map",
-    "./styles.css": "./styles.css",
-    "./styles.css.map": "./styles.css.map",
+    "./esm.js": "path/to/esm.js",
+    "./esm.js.map": "path/to/esm.js.map",
+    "./styles.css": "path/to/styles.css",
+    "./styles.css.map": "path/to/styles.css.map",
   }
 }
 ```
 
-This will result in 7 files at the following locations:
+This will result in files at the following locations:
 
 * `/pkg/<name>/<version>/eik.json`
 * `/pkg/<name>/<version>/esm.js`
 * `/pkg/<name>/<version>/esm.js.map`
-* `/pkg/<name>/<version>/ie11.js`
-* `/pkg/<name>/<version>/ie11.js.map`
 * `/pkg/<name>/<version>/styles.css`
 * `/pkg/<name>/<version>/styles.css.map`
 

--- a/docs/overview_workflow.md
+++ b/docs/overview_workflow.md
@@ -20,9 +20,9 @@ When applying mapping ahead of time there must be a build step regardless if the
 
 When your build process runs, the Eik plugin used with the build tool will fetch the defined import maps from the Eik server defined for the project. When the build process is complete, the built application assets should be stored in one or more output folders. 
 
-The next step in the workflow is uploading the built application assets to the Eik server. This is done by the [Eik client](/docs/client_app_packages).
+The next step in the workflow is uploading the built application assets to the Eik server. This is done using the [Eik client](/docs/client_app_packages).
 
-Upon upload Eik will calculate integrity hashes and store these in `./eik/integrity.json`. These hashes can be used for [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) and should be used when referring to your assets in your HTML.
+Upon upload, Eik will calculate integrity hashes and store these in `./eik/integrity.json`. These hashes can be used for [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) and should be used when referring to your assets in your HTML.
 
 At this point your application assets are available on the Eik server and the server side part of the application can be applied to production by referring to the assets on the Eik server in the HTML.
 
@@ -30,17 +30,17 @@ At this point your application assets are available on the Eik server and the se
 
 When working with mapping in the browser the workflow is as follows:
 
-![Workflow of abrowser mapping](/img/workflow_browser_mapping.min.svg)
+![Workflow of browser mapping](/img/workflow_browser_mapping.min.svg)
 
 As previously mentioned, Eik doesn't force any particular structure for how your source code should be organized and when it comes to mapping in the browser, the question of whether or not your project should have a build step is completely up to you. The important thing to note with regards to build steps is that the `files` field in `eik.json` must point to either your source files in the case where you have no build step or to the files in the output folder of your build step if you do.
 
-The main step in this workflow is uploading the assets to the Eik server. This is done by the [Eik client](/docs/client_app_packages).
+The main step in this workflow is uploading the assets to the Eik server. This is done using the [Eik client](/docs/client_app_packages).
 
-Upon upload Eik will calculate integrity hashes and store these in `./eik/integrity.json`. These hashes can be used for [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) and should be used when referring your assets in your HTML.
+Upon upload, Eik will calculate integrity hashes and store these in `./eik/integrity.json`. These hashes can be used for [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) and should be used when referring to your assets in your HTML.
 
-At this point your application assets will be available on the Eik server and the server side part of the application can be applied to production referring to the assets on the Eik server in the HTML.
+At this point your application assets will be available on the Eik server and the server side part of the application can be deployed to production where it will refer to its assets on the Eik server via HTML script and link tags.
 
-To apply the mapping the server side part of the application should also pull the import maps, defined in the eik.json, from the Eik server and include these in the HTML as inline script blocks as according to the specification.
+To apply the mapping, the server side part of the application should also pull the import maps, defined in the eik.json, from the Eik server and include these in the HTML as inline script blocks according to the specification.
 
 ## Referencing assets
 


### PR DESCRIPTION
Docs updates for v2. Rollup examples instead of micro bundle. PRing against next branch.